### PR TITLE
fix: add auth to local mixed inbound to prevent IP leak

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
@@ -41,6 +41,7 @@ object Key {
     const val CONCURRENT_DIAL = "concurrentDial"
 
     const val MIXED_PORT = "mixedPort"
+    const val MIXED_SECRET = "mixedSecret"
     const val ALLOW_ACCESS = "allowAccess"
     const val SPEED_INTERVAL = "speedInterval"
     const val SHOW_DIRECT_SPEED = "showDirectSpeed"

--- a/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
@@ -138,10 +138,24 @@ object DataStore : OnPreferenceDataStoreChangeListener {
         get() = getLocalPort(Key.MIXED_PORT, 2080)
         set(value) = saveLocalPort(Key.MIXED_PORT, value)
 
+    // Random secret for local mixed inbound authentication.
+    // Prevents other apps on the device from connecting to the proxy directly
+    // (bypassing VpnService) and discovering the real server IP.
+    val mixedSecret: String
+        get() {
+            val existing = configurationStore.getString(Key.MIXED_SECRET)
+            if (!existing.isNullOrEmpty()) return existing
+            val generated = java.util.UUID.randomUUID().toString().replace("-", "")
+            configurationStore.putString(Key.MIXED_SECRET, generated)
+            return generated
+        }
+
     fun initGlobal() {
         if (configurationStore.getString(Key.MIXED_PORT) == null) {
             mixedPort = mixedPort
         }
+        // Ensure secret is generated on first run
+        mixedSecret
     }
 
 

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -254,6 +254,12 @@ fun buildConfig(
                 domain_strategy = genDomainStrategy(DataStore.resolveDestination)
                 sniff = needSniff
                 sniff_override_destination = needSniffOverride
+                // Fix: add random auth to prevent any app on device from using this proxy
+                // directly (bypassing VpnService) and leaking the real server IP.
+                users = listOf(User().also { u ->
+                    u.username = "neko"
+                    u.password = DataStore.mixedSecret
+                })
             })
         }
 

--- a/app/src/main/java/io/nekohasekai/sagernet/group/RawUpdater.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/group/RawUpdater.kt
@@ -61,7 +61,7 @@ object RawUpdater : GroupUpdater() {
         } else {
 
             val response = Libcore.newHttpClient().apply {
-                trySocks5(DataStore.mixedPort)
+                trySocks5(DataStore.mixedPort, "neko", DataStore.mixedSecret)
                 tryH3Direct()
                 when (DataStore.appTLSVersion) {
                     "1.3" -> restrictedTLS()

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/AboutFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/AboutFragment.kt
@@ -216,7 +216,7 @@ class AboutFragment : ToolbarFragment(R.layout.layout_about) {
                 try {
                     val client = Libcore.newHttpClient().apply {
                         modernTLS()
-                        trySocks5(DataStore.mixedPort)
+                        trySocks5(DataStore.mixedPort, "neko", DataStore.mixedSecret)
                     }
                     val response = client.newRequest().apply {
                         if (checkPreview) {

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/AssetsActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/AssetsActivity.kt
@@ -282,7 +282,7 @@ class AssetsActivity : ThemedActivity() {
         val client = Libcore.newHttpClient().apply {
             modernTLS()
             keepAlive()
-            trySocks5(DataStore.mixedPort)
+            trySocks5(DataStore.mixedPort, "neko", DataStore.mixedSecret)
         }
 
         try {
@@ -345,7 +345,7 @@ class AssetsActivity : ThemedActivity() {
         val client = Libcore.newHttpClient().apply {
             modernTLS()
             keepAlive()
-            trySocks5(DataStore.mixedPort)
+            trySocks5(DataStore.mixedPort, "neko", DataStore.mixedSecret)
         }
         try {
             val response = client.newRequest().apply {

--- a/libcore/http.go
+++ b/libcore/http.go
@@ -36,7 +36,7 @@ type HTTPClient interface {
 	ModernTLS()
 	PinnedTLS12()
 	PinnedSHA256(sumHex string)
-	TrySocks5(port int32)
+	TrySocks5(port int32, username string, password string)
 	TryH3Direct()
 	KeepAlive()
 	NewRequest() HTTPRequest
@@ -114,7 +114,7 @@ func (c *httpClient) PinnedSHA256(sumHex string) {
 	}
 }
 
-func (c *httpClient) TrySocks5(port int32) {
+func (c *httpClient) TrySocks5(port int32, username string, password string) {
 	dialer := new(net.Dialer)
 	c.h1h2Transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		for {
@@ -125,7 +125,7 @@ func (c *httpClient) TrySocks5(port int32) {
 				}
 				break
 			}
-			_, err = socks.ClientHandshake5(socksConn, socks5.CommandConnect, metadata.ParseSocksaddr(addr), "", "")
+			_, err = socks.ClientHandshake5(socksConn, socks5.CommandConnect, metadata.ParseSocksaddr(addr), username, password)
 			if err != nil {
 				if c.tryH3Direct {
 					return nil, errFailConnectSocks5


### PR DESCRIPTION
All popular VLESS/xray/sing-box clients expose a local SOCKS5 proxy without authentication. Any app on the device can connect to it directly, bypassing VpnService, and discover the real outbound server IP.

Fix: generate a random secret on first run (UUID, stored in SharedPreferences) and set it as the password for the mixed inbound. All internal HTTP clients (subscription updates, asset downloads, update checker) are updated to pass the credentials when connecting to the local proxy.

Changed files:
- Constants.kt          — add MIXED_SECRET key
- DataStore.kt          — add mixedSecret property (lazy UUID generation)
- ConfigBuilder.kt      — set users=[{username, password}] on Inbound_MixedOptions
- libcore/http.go       — TrySocks5(port) → TrySocks5(port, username, password)
- AssetsActivity.kt     — pass credentials to trySocks5 (2 calls)
- AboutFragment.kt      — pass credentials to trySocks5
- RawUpdater.kt         — pass credentials to trySocks5