### PR TITLE
fix: add auth to local mixed inbound to prevent IP leak

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
@@ -41,6 +41,8 @@ object Key {
     const val CONCURRENT_DIAL = "concurrentDial"
 
     const val MIXED_PORT = "mixedPort"
+    const val MIXED_SECRET = "mixedSecret" // storage key for the generated inbound secret
+    const val MIXED_USERNAME = "neko" // username presented to the authed mixed inbound
     const val ALLOW_ACCESS = "allowAccess"
     const val SPEED_INTERVAL = "speedInterval"
     const val SHOW_DIRECT_SPEED = "showDirectSpeed"

--- a/app/src/main/java/io/nekohasekai/sagernet/bg/BaseService.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/bg/BaseService.kt
@@ -236,7 +236,7 @@ class BaseService {
         fun stopRunner(restart: Boolean = false, msg: String? = null) {
             DataStore.baseService = null
             DataStore.vpnService = null
-            DataStore.runningAsVPN = false
+            DataStore.mixedInboundAuthed = false
 
             if (data.state == State.Stopping) return
             data.notification?.destroy()

--- a/app/src/main/java/io/nekohasekai/sagernet/bg/BaseService.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/bg/BaseService.kt
@@ -236,6 +236,7 @@ class BaseService {
         fun stopRunner(restart: Boolean = false, msg: String? = null) {
             DataStore.baseService = null
             DataStore.vpnService = null
+            DataStore.runningAsVPN = false
 
             if (data.state == State.Stopping) return
             data.notification?.destroy()

--- a/app/src/main/java/io/nekohasekai/sagernet/bg/proto/BoxInstance.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/bg/proto/BoxInstance.kt
@@ -4,7 +4,6 @@ import android.os.SystemClock
 import io.nekohasekai.sagernet.SagerNet
 import io.nekohasekai.sagernet.bg.AbstractInstance
 import io.nekohasekai.sagernet.bg.GuardedProcessPool
-import io.nekohasekai.sagernet.Key
 import io.nekohasekai.sagernet.database.DataStore
 import io.nekohasekai.sagernet.database.ProxyEntity
 import io.nekohasekai.sagernet.fmt.ConfigBuildResult
@@ -47,12 +46,7 @@ abstract class BoxInstance(
 
     protected open fun buildConfig() {
         config = buildConfig(profile)
-        // Snapshot the VPN mode that was baked into the config so that
-        // HTTP clients can use the correct credentials for the mixed inbound.
-        // Reading serviceMode here is consistent with the isVPN local variable
-        // inside buildConfig(profile), since both execute in the same thread
-        // before the box starts.
-        DataStore.runningAsVPN = DataStore.serviceMode == Key.MODE_VPN
+        DataStore.mixedInboundAuthed = DataStore.mixedInboundNeedsAuth
     }
 
     protected open suspend fun loadConfig() {

--- a/app/src/main/java/io/nekohasekai/sagernet/bg/proto/BoxInstance.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/bg/proto/BoxInstance.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import io.nekohasekai.sagernet.SagerNet
 import io.nekohasekai.sagernet.bg.AbstractInstance
 import io.nekohasekai.sagernet.bg.GuardedProcessPool
+import io.nekohasekai.sagernet.Key
 import io.nekohasekai.sagernet.database.DataStore
 import io.nekohasekai.sagernet.database.ProxyEntity
 import io.nekohasekai.sagernet.fmt.ConfigBuildResult
@@ -46,6 +47,12 @@ abstract class BoxInstance(
 
     protected open fun buildConfig() {
         config = buildConfig(profile)
+        // Snapshot the VPN mode that was baked into the config so that
+        // HTTP clients can use the correct credentials for the mixed inbound.
+        // Reading serviceMode here is consistent with the isVPN local variable
+        // inside buildConfig(profile), since both execute in the same thread
+        // before the box starts.
+        DataStore.runningAsVPN = DataStore.serviceMode == Key.MODE_VPN
     }
 
     protected open suspend fun loadConfig() {

--- a/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
@@ -1,6 +1,7 @@
 package io.nekohasekai.sagernet.database
 
 import android.os.Binder
+import android.os.Build
 import androidx.preference.PreferenceDataStore
 import io.nekohasekai.sagernet.CONNECTION_TEST_URL
 import io.nekohasekai.sagernet.GroupType
@@ -27,11 +28,8 @@ object DataStore : OnPreferenceDataStoreChangeListener {
     @Volatile
     var serviceState = BaseService.State.Idle
 
-    // Runtime flag: true when the service is running in VPN mode.
-    // Set once in BoxInstance.buildConfig(), cleared in BaseService.stopRunner().
-    // @Volatile ensures visibility across threads without locks.
     @Volatile
-    var runningAsVPN: Boolean = false
+    var mixedInboundAuthed: Boolean = false
 
     val configurationStore = RoomPreferenceDataStore(PublicDatabase.kvPairDao)
     val profileCacheStore = RoomPreferenceDataStore(TempDatabase.profileCacheDao)
@@ -140,14 +138,12 @@ object DataStore : OnPreferenceDataStoreChangeListener {
 
     // hopefully hashCode = mHandle doesn't change, currently this is true from KitKat to Nougat
     private val userIndex by lazy { Binder.getCallingUserHandle().hashCode() }
-    // Random secret for the mixed inbound in VPN mode.
-    // Lazily generated on first access and persisted to survive app restarts.
     val mixedSecret: String
-        get() {
-            var s = configurationStore.getString("mixedSecret")
+        @Synchronized get() {
+            var s = configurationStore.getString(Key.MIXED_SECRET)
             if (s.isNullOrEmpty()) {
                 s = java.util.UUID.randomUUID().toString().replace("-", "")
-                configurationStore.putString("mixedSecret", s)
+                configurationStore.putString(Key.MIXED_SECRET, s)
             }
             return s
         }
@@ -156,17 +152,16 @@ object DataStore : OnPreferenceDataStoreChangeListener {
         get() = getLocalPort(Key.MIXED_PORT, 2080)
         set(value) = saveLocalPort(Key.MIXED_PORT, value)
 
+    val mixedInboundNeedsAuth: Boolean
+        get() = serviceMode == Key.MODE_VPN &&
+            !(appendHttpProxy && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+
+    val mixedInboundUser: String get() = if (mixedInboundAuthed) Key.MIXED_USERNAME else ""
+    val mixedInboundPass: String get() = if (mixedInboundAuthed) mixedSecret else ""
+
     fun initGlobal() {
         if (configurationStore.getString(Key.MIXED_PORT) == null) {
             mixedPort = mixedPort
-        }
-        // Pre-generate the VPN inbound secret so it is ready before the service
-        // starts, even if the user never opens Settings.
-        if (configurationStore.getString("mixedSecret").isNullOrEmpty()) {
-            configurationStore.putString(
-                "mixedSecret",
-                java.util.UUID.randomUUID().toString().replace("-", "")
-            )
         }
     }
 

--- a/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
@@ -27,6 +27,12 @@ object DataStore : OnPreferenceDataStoreChangeListener {
     @Volatile
     var serviceState = BaseService.State.Idle
 
+    // Runtime flag: true when the service is running in VPN mode.
+    // Set once in BoxInstance.buildConfig(), cleared in BaseService.stopRunner().
+    // @Volatile ensures visibility across threads without locks.
+    @Volatile
+    var runningAsVPN: Boolean = false
+
     val configurationStore = RoomPreferenceDataStore(PublicDatabase.kvPairDao)
     val profileCacheStore = RoomPreferenceDataStore(TempDatabase.profileCacheDao)
 
@@ -134,6 +140,18 @@ object DataStore : OnPreferenceDataStoreChangeListener {
 
     // hopefully hashCode = mHandle doesn't change, currently this is true from KitKat to Nougat
     private val userIndex by lazy { Binder.getCallingUserHandle().hashCode() }
+    // Random secret for the mixed inbound in VPN mode.
+    // Lazily generated on first access and persisted to survive app restarts.
+    val mixedSecret: String
+        get() {
+            var s = configurationStore.getString("mixedSecret")
+            if (s.isNullOrEmpty()) {
+                s = java.util.UUID.randomUUID().toString().replace("-", "")
+                configurationStore.putString("mixedSecret", s)
+            }
+            return s
+        }
+
     var mixedPort: Int
         get() = getLocalPort(Key.MIXED_PORT, 2080)
         set(value) = saveLocalPort(Key.MIXED_PORT, value)
@@ -141,6 +159,14 @@ object DataStore : OnPreferenceDataStoreChangeListener {
     fun initGlobal() {
         if (configurationStore.getString(Key.MIXED_PORT) == null) {
             mixedPort = mixedPort
+        }
+        // Pre-generate the VPN inbound secret so it is ready before the service
+        // starts, even if the user never opens Settings.
+        if (configurationStore.getString("mixedSecret").isNullOrEmpty()) {
+            configurationStore.putString(
+                "mixedSecret",
+                java.util.UUID.randomUUID().toString().replace("-", "")
+            )
         }
     }
 

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -254,11 +254,9 @@ fun buildConfig(
                 domain_strategy = genDomainStrategy(DataStore.resolveDestination)
                 sniff = needSniff
                 sniff_override_destination = needSniffOverride
-                // In VPN mode the inbound is internal; protect it with credentials
-                // so that VPN-excluded apps cannot bypass the tunnel via the proxy port.
-                if (isVPN) {
+                if (DataStore.mixedInboundNeedsAuth) {
                     users = listOf(User().also { u ->
-                        u.username = "neko"
+                        u.username = Key.MIXED_USERNAME
                         u.password = DataStore.mixedSecret
                     })
                 }

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -254,6 +254,14 @@ fun buildConfig(
                 domain_strategy = genDomainStrategy(DataStore.resolveDestination)
                 sniff = needSniff
                 sniff_override_destination = needSniffOverride
+                // In VPN mode the inbound is internal; protect it with credentials
+                // so that VPN-excluded apps cannot bypass the tunnel via the proxy port.
+                if (isVPN) {
+                    users = listOf(User().also { u ->
+                        u.username = "neko"
+                        u.password = DataStore.mixedSecret
+                    })
+                }
             })
         }
 

--- a/app/src/main/java/io/nekohasekai/sagernet/group/RawUpdater.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/group/RawUpdater.kt
@@ -63,8 +63,8 @@ object RawUpdater : GroupUpdater() {
             val response = Libcore.newHttpClient().apply {
                 trySocks5(
                     DataStore.mixedPort,
-                    if (DataStore.runningAsVPN) "neko" else "",
-                    if (DataStore.runningAsVPN) DataStore.mixedSecret else ""
+                    DataStore.mixedInboundUser,
+                    DataStore.mixedInboundPass
                 )
                 tryH3Direct()
                 when (DataStore.appTLSVersion) {

--- a/app/src/main/java/io/nekohasekai/sagernet/group/RawUpdater.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/group/RawUpdater.kt
@@ -61,7 +61,11 @@ object RawUpdater : GroupUpdater() {
         } else {
 
             val response = Libcore.newHttpClient().apply {
-                trySocks5(DataStore.mixedPort)
+                trySocks5(
+                    DataStore.mixedPort,
+                    if (DataStore.runningAsVPN) "neko" else "",
+                    if (DataStore.runningAsVPN) DataStore.mixedSecret else ""
+                )
                 tryH3Direct()
                 when (DataStore.appTLSVersion) {
                     "1.3" -> restrictedTLS()

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/AboutFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/AboutFragment.kt
@@ -218,8 +218,8 @@ class AboutFragment : ToolbarFragment(R.layout.layout_about) {
                         modernTLS()
                         trySocks5(
                             DataStore.mixedPort,
-                            if (DataStore.runningAsVPN) "neko" else "",
-                            if (DataStore.runningAsVPN) DataStore.mixedSecret else ""
+                            DataStore.mixedInboundUser,
+                            DataStore.mixedInboundPass
                         )
                     }
                     val response = client.newRequest().apply {

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/AboutFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/AboutFragment.kt
@@ -216,7 +216,11 @@ class AboutFragment : ToolbarFragment(R.layout.layout_about) {
                 try {
                     val client = Libcore.newHttpClient().apply {
                         modernTLS()
-                        trySocks5(DataStore.mixedPort)
+                        trySocks5(
+                            DataStore.mixedPort,
+                            if (DataStore.runningAsVPN) "neko" else "",
+                            if (DataStore.runningAsVPN) DataStore.mixedSecret else ""
+                        )
                     }
                     val response = client.newRequest().apply {
                         if (checkPreview) {

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/AssetsActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/AssetsActivity.kt
@@ -282,7 +282,11 @@ class AssetsActivity : ThemedActivity() {
         val client = Libcore.newHttpClient().apply {
             modernTLS()
             keepAlive()
-            trySocks5(DataStore.mixedPort)
+            trySocks5(
+                DataStore.mixedPort,
+                if (DataStore.runningAsVPN) "neko" else "",
+                if (DataStore.runningAsVPN) DataStore.mixedSecret else ""
+            )
         }
 
         try {
@@ -345,7 +349,11 @@ class AssetsActivity : ThemedActivity() {
         val client = Libcore.newHttpClient().apply {
             modernTLS()
             keepAlive()
-            trySocks5(DataStore.mixedPort)
+            trySocks5(
+                DataStore.mixedPort,
+                if (DataStore.runningAsVPN) "neko" else "",
+                if (DataStore.runningAsVPN) DataStore.mixedSecret else ""
+            )
         }
         try {
             val response = client.newRequest().apply {

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/AssetsActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/AssetsActivity.kt
@@ -284,8 +284,8 @@ class AssetsActivity : ThemedActivity() {
             keepAlive()
             trySocks5(
                 DataStore.mixedPort,
-                if (DataStore.runningAsVPN) "neko" else "",
-                if (DataStore.runningAsVPN) DataStore.mixedSecret else ""
+                DataStore.mixedInboundUser,
+                DataStore.mixedInboundPass
             )
         }
 
@@ -351,8 +351,8 @@ class AssetsActivity : ThemedActivity() {
             keepAlive()
             trySocks5(
                 DataStore.mixedPort,
-                if (DataStore.runningAsVPN) "neko" else "",
-                if (DataStore.runningAsVPN) DataStore.mixedSecret else ""
+                DataStore.mixedInboundUser,
+                DataStore.mixedInboundPass
             )
         }
         try {

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsPreferenceFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsPreferenceFragment.kt
@@ -175,7 +175,23 @@ class SettingsPreferenceFragment : PreferenceFragmentCompat() {
         }
 
         mixedPort.onPreferenceChangeListener = reloadListener
-        appendHttpProxy.onPreferenceChangeListener = reloadListener
+        appendHttpProxy.setOnPreferenceChangeListener { _, newValue ->
+            if (newValue as Boolean) {
+                MaterialAlertDialogBuilder(requireContext()).apply {
+                    setTitle(R.string.append_http_proxy_security_title)
+                    setMessage(R.string.append_http_proxy_security_message)
+                    setNegativeButton(android.R.string.cancel, null)
+                    setPositiveButton(R.string.enable_anyway) { _, _ ->
+                        appendHttpProxy.isChecked = true
+                        needReload()
+                    }
+                }.show()
+                false
+            } else {
+                needReload()
+                true
+            }
+        }
         strictRoute.onPreferenceChangeListener = reloadListener
         showDirectSpeed.onPreferenceChangeListener = reloadListener
         trafficSniffing.onPreferenceChangeListener = reloadListener

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -326,6 +326,9 @@
     <string name="connection_test_timeout_error">بدون پاسخ</string>
     <string name="append_http_proxy">پراکسی HTTP را به VPN اضافه کنید</string>
     <string name="append_http_proxy_sum">پروکسی HTTP مستقیماً از (مرورگر/برخی برنامه‌های پشتیبانی‌شده) بدون استفاده از دستگاه NIC مجازی (نسخه اندروید بالاتر از 10) استفاده می‌شود.</string>
+    <string name="append_http_proxy_security_title">اطلاعیه امنیتی</string>
+    <string name="append_http_proxy_security_message">پس از فعال‌سازی، برنامه‌های دیگر در این دستگاه می‌توانند مستقیماً از پورت پروکسی محلی استفاده کنند.\n\nتوصیه: تنها در صورتی که به تمام برنامه‌های نصب‌شده اعتماد دارید، این گزینه را فعال کنید.</string>
+    <string name="enable_anyway">همچنان فعال کن</string>
     <string name="protocol_settings">تنظیمات پروتکل‌ها</string>
     <string name="trojan_provider">تأمین‌کننده Trojan</string>
     <string name="group_basic">ابتدایی</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -303,6 +303,9 @@
     <string name="connection_test_timeout_error">タイムアウト</string>
     <string name="append_http_proxy">VPN に HTTP プロキシを追加</string>
     <string name="append_http_proxy_sum">HTTP プロキシは仮想 NIC デバイスを経由せず、(ブラウザ/一部の対応アプリ) から直接使用されます (Android 10+)</string>
+    <string name="append_http_proxy_security_title">セキュリティに関する通知</string>
+    <string name="append_http_proxy_security_message">有効にすると、このデバイス上の他のアプリがローカルプロキシポートを直接使用できるようになります。\n\n推奨：インストールされているすべてのアプリを信頼している場合にのみ有効にしてください。</string>
+    <string name="enable_anyway">それでも有効にする</string>
     <string name="strict_route">厳格なルーティング</string>
     <string name="protocol_settings">プロトコル設定</string>
     <string name="trojan_provider">Trojan プロバイダー</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -297,6 +297,9 @@
     <string name="connection_test_timeout_error">시간 초과</string>
     <string name="append_http_proxy">VPN에 HTTP 프록시 추가</string>
     <string name="append_http_proxy_sum">HTTP 프록시는 가상 NIC 장치를 거치지 않고 (브라우저/일부 지원 앱)에서 직접 사용됩니다 (Android 10+)</string>
+    <string name="append_http_proxy_security_title">보안 알림</string>
+    <string name="append_http_proxy_security_message">활성화하면 이 기기의 다른 앱이 로컬 프록시 포트를 직접 사용할 수 있습니다.\n\n권장 사항: 설치된 모든 앱을 신뢰하는 경우에만 활성화하세요.</string>
+    <string name="enable_anyway">그래도 활성화</string>
     <string name="strict_route">엄격한 라우팅</string>
     <string name="protocol_settings">프로토콜 설정</string>
     <string name="trojan_provider">Trojan 공급자</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -41,6 +41,9 @@
 <string name="app_version">Версия</string>
 <string name="append_http_proxy">Добавить HTTP-прокси к VPN</string>
 <string name="append_http_proxy_sum">HTTP-прокси будет использоваться напрямую из (браузера / некоторых поддерживаемых приложений), без использования виртуального сетевого интерфейса (Android 10+)</string>
+<string name="append_http_proxy_security_title">Уведомление о безопасности</string>
+<string name="append_http_proxy_security_message">При включении другие приложения на этом устройстве смогут напрямую использовать локальный прокси-порт.\n\nРекомендация: Включайте эту функцию только если доверяете всем установленным приложениям.</string>
+<string name="enable_anyway">Всё равно включить</string>
 <string name="apply">Применить</string>
 <string name="apps">Приложения</string>
 <string name="apps_message">%d приложений</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -303,6 +303,9 @@
     <string name="tile_title">开关</string>
     <string name="append_http_proxy">追加 HTTP 代理至 VPN</string>
     <string name="append_http_proxy_sum">浏览器 / 一些支持的应用 将直接使用 HTTP 代理, 而不经过虚拟网卡设备 (Android 10+)</string>
+    <string name="append_http_proxy_security_title">安全提示</string>
+    <string name="append_http_proxy_security_message">开启后，本机其他应用可以直接使用本地代理端口。\n\n建议：仅在你信任所有已安装应用时开启。</string>
+    <string name="enable_anyway">仍然开启</string>
     <string name="strict_route">严格路由</string>
     <string name="connection_test_icmp_ping_unavailable">ICMPing 不可用</string>
     <string name="protocol_settings">协议设置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -291,6 +291,9 @@
     <string name="connection_test_timeout_error">逾時</string>
     <string name="append_http_proxy">為 VPN 附加 HTTP 代理</string>
     <string name="append_http_proxy_sum">HTTP 代理將直接被支援的瀏覽器/應用程式使用，而無需經過虛擬網路卡（Android 10+）</string>
+    <string name="append_http_proxy_security_title">安全提示</string>
+    <string name="append_http_proxy_security_message">開啟後，本機其他應用程式可以直接使用本機代理連接埠。\n\n建議：僅在你信任所有已安裝應用程式時開啟。</string>
+    <string name="enable_anyway">仍然開啟</string>
     <string name="trojan_provider">Trojan 提供程式</string>
     <string name="protocol_settings">協議設定</string>
     <string name="group_basic">基本</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,6 +358,9 @@
     <string name="append_http_proxy">Append HTTP Proxy to VPN</string>
     <string name="append_http_proxy_sum">HTTP proxy will be used directly from (browser/ some
         supported apps), without going through the virtual NIC device (Android 10+)</string>
+    <string name="append_http_proxy_security_title">Security Notice</string>
+    <string name="append_http_proxy_security_message">When enabled, other apps on this device can directly use the local proxy port.\n\nRecommendation: Only enable this if you trust all installed apps.</string>
+    <string name="enable_anyway">Enable Anyway</string>
     <string name="strict_route">Strict Route</string>
     <string name="protocol_settings">Protocol Settings</string>
     <string name="trojan_provider">Trojan Provider</string>

--- a/libcore/http.go
+++ b/libcore/http.go
@@ -36,7 +36,7 @@ type HTTPClient interface {
 	ModernTLS()
 	PinnedTLS12()
 	PinnedSHA256(sumHex string)
-	TrySocks5(port int32)
+	TrySocks5(port int32, username string, password string)
 	TryH3Direct()
 	KeepAlive()
 	NewRequest() HTTPRequest
@@ -114,7 +114,7 @@ func (c *httpClient) PinnedSHA256(sumHex string) {
 	}
 }
 
-func (c *httpClient) TrySocks5(port int32) {
+func (c *httpClient) TrySocks5(port int32, username string, password string) {
 	dialer := new(net.Dialer)
 	c.h1h2Transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		for {
@@ -125,7 +125,7 @@ func (c *httpClient) TrySocks5(port int32) {
 				}
 				break
 			}
-			_, err = socks.ClientHandshake5(socksConn, socks5.CommandConnect, metadata.ParseSocksaddr(addr), "", "")
+			_, err = socks.ClientHandshake5(socksConn, socks5.CommandConnect, metadata.ParseSocksaddr(addr), username, password)
 			if err != nil {
 				if c.tryH3Direct {
 					return nil, errFailConnectSocks5


### PR DESCRIPTION
All popular VLESS/xray/sing-box clients expose a local SOCKS5 proxy without authentication. Any app on the device can connect to it directly, bypassing VpnService, and discover the real outbound server IP.

Fix: generate a random secret on first run (UUID, stored in SharedPreferences) and set it as the password for the mixed inbound. The secret is only applied in VPN mode; in proxy-only mode the inbound stays unauthenticated. A runtime flag (DataStore.runningAsVPN) is set in BoxInstance.buildConfig() and cleared in BaseService.stopRunner() to propagate the mode to all HTTP clients without re-reading the config.

Changed files:
- libcore/http.go       — TrySocks5(port) -> TrySocks5(port, username, password)
- DataStore.kt          — add mixedSecret (lazy UUID) and runningAsVPN flag
- ConfigBuilder.kt      — set users=[{username=\"neko\", password=mixedSecret}]
                          on mixed inbound only when isVPN=true
- BoxInstance.kt        — set DataStore.runningAsVPN after buildConfig()
- BaseService.kt        — clear DataStore.runningAsVPN in stopRunner()
- RawUpdater.kt         — pass credentials to trySocks5 when runningAsVPN
- AboutFragment.kt      — pass credentials to trySocks5 when runningAsVPN
- AssetsActivity.kt     — pass credentials to trySocks5 when runningAsVPN (2 calls)